### PR TITLE
Fix bar alignment to grow from bottom to top in visualizer

### DIFF
--- a/src/main/java/app/view/SortingVisualizer.java
+++ b/src/main/java/app/view/SortingVisualizer.java
@@ -17,6 +17,7 @@ public class SortingVisualizer extends HBox {
 
     public SortingVisualizer() {
         this.setSpacing(2);
+        this.setStyle("-fx-alignment: bottom-center;");
         generateRandomArray();
         createBars();
 


### PR DESCRIPTION
- Set alignment to bottom-center in SortingVisualizer
- Bars now grow upward from the base as expected

Closes #7 
