### PR TITLE
Fix: disable all controls including speed slider during sorting

### DIFF
--- a/src/main/java/app/algorithms/BubbleSort.java
+++ b/src/main/java/app/algorithms/BubbleSort.java
@@ -1,28 +1,35 @@
 package app.algorithms;
 
 import app.view.SortingVisualizer;
+import app.controller.SortController;
+
 import javafx.application.Platform;
 import javafx.scene.paint.Color;
 import javafx.scene.shape.Rectangle;
 
-public class BubbleSort implements SortAlgorithm {
 
+public class BubbleSort implements SortAlgorithm {
+    
     private final SortingVisualizer visualizer;
     private final int[] values;
     private final Rectangle[] bars;
     private final int delay;
+    private final SortController controller;
 
-    public BubbleSort(SortingVisualizer visualizer, int delay) {
+    public BubbleSort(SortingVisualizer visualizer, SortController controller, int delay) {
         this.visualizer = visualizer;
         this.values = visualizer.getValues();
         this.bars = visualizer.getBars();
         this.delay = delay;
+        this.controller = controller;
     }
 
     @Override
     public void sort() throws InterruptedException {
         new Thread(() -> {
             try {
+                Platform.runLater(() -> controller.setAllControlsDisabled(true));
+
                 for (int i = 0; i < values.length - 1; i++) {
                     for (int j = 0; j < values.length - i - 1; j++) {
                         highlight(j, j + 1, Color.RED);
@@ -38,6 +45,8 @@ public class BubbleSort implements SortAlgorithm {
                 }
             } catch (InterruptedException e) {
                 Thread.currentThread().interrupt();
+            } finally {
+                Platform.runLater(() -> controller.setAllControlsDisabled(false));
             }
         }).start();
     }

--- a/src/main/java/app/controller/SortController.java
+++ b/src/main/java/app/controller/SortController.java
@@ -2,6 +2,7 @@ package app.controller;
 
 import app.algorithms.BubbleSort;
 import app.view.SortingVisualizer;
+
 import javafx.geometry.Insets;
 import javafx.scene.control.Button;
 import javafx.scene.control.Label;
@@ -32,7 +33,7 @@ public class SortController extends HBox {
 
         startButton.setOnAction(e -> {
             int delay = (int) speedSlider.getValue();
-            BubbleSort bubbleSort = new BubbleSort(visualizer, delay);
+            BubbleSort bubbleSort = new BubbleSort(visualizer, this, delay);
             try {
                 bubbleSort.sort();
             } catch (InterruptedException ex) {
@@ -42,4 +43,11 @@ public class SortController extends HBox {
 
         this.getChildren().addAll(newArrayButton, startButton, speedLabel, speedSlider);
     }
+
+    public void setAllControlsDisabled(boolean disabled) {
+        newArrayButton.setDisable(disabled);
+        startButton.setDisable(disabled);
+        speedSlider.setDisable(disabled);
+    }
+
 }


### PR DESCRIPTION
- Disabled "Start", "New Array", and speed slider while sorting is running
- Prevents overlapping animations and misleading slider use
- Re-enables controls after completion

Closes #13 